### PR TITLE
runners: remove macos 15 intel.

### DIFF
--- a/.github/runners.json
+++ b/.github/runners.json
@@ -9,11 +9,6 @@
         "runs_on": "macos-15",
         "cleanup_before": true
     },
-        {
-        "name": "macOS 15 (intel)",
-        "runs_on": "macos-15-intel",
-        "cleanup_before": true
-    },
     {
         "name": "macOS 14 (arm64)",
         "runs_on": "macos-14",


### PR DESCRIPTION
Homebrew doesn't build bottles, so it isn't worth running these.