### PR TITLE
imsg 0.13.4 (new formula)

### DIFF
--- a/Formula/imsg.rb
+++ b/Formula/imsg.rb
@@ -5,8 +5,14 @@ class Imsg < Formula
   sha256 "5fa216f8664cbc8abf4b0fe396d24f6c96b7e962d8a7c924d965d3d9e5068a8e"
   license "MIT"
 
-  # SQLite.swift needs swift-tools-version 6.1, first shipped in Xcode 16.3.
-  depends_on macos: :sequoia
+  # A version-specified macOS requirement is satisfied on Linux, so the bare one
+  # is what actually keeps this off a platform it cannot support.
+  depends_on :macos
+
+  on_macos do
+    # SQLite.swift needs swift-tools-version 6.1, first shipped in Xcode 16.3.
+    depends_on macos: :sequoia
+  end
 
   # Vendored because SwiftPM cannot fetch dependencies during a Homebrew build.
   # Versions match upstream's Package.resolved for this tag.

--- a/Formula/imsg.rb
+++ b/Formula/imsg.rb
@@ -1,0 +1,102 @@
+class Imsg < Formula
+  desc "Send and read iMessage / SMS from the terminal"
+  homepage "https://github.com/openclaw/imsg"
+  url "https://github.com/openclaw/imsg/archive/refs/tags/v0.13.4.tar.gz"
+  sha256 "5fa216f8664cbc8abf4b0fe396d24f6c96b7e962d8a7c924d965d3d9e5068a8e"
+  license "MIT"
+
+  # SQLite.swift needs swift-tools-version 6.1, first shipped in Xcode 16.3.
+  depends_on macos: :sequoia
+
+  # Vendored because SwiftPM cannot fetch dependencies during a Homebrew build.
+  # Versions match upstream's Package.resolved for this tag.
+  resource "Commander" do
+    url "https://github.com/steipete/Commander/archive/refs/tags/v0.2.4.tar.gz"
+    sha256 "33adc1d87615be729dceea38ee0358dec8484f35f7070caac29fe5e1902fcbd3"
+  end
+
+  resource "PhoneNumberKit" do
+    url "https://github.com/PhoneNumberKit/PhoneNumberKit/archive/refs/tags/5.0.5.tar.gz"
+    sha256 "81230573de9717e9a9f7980f4581355c042e234d252cddef69d54179ba5f54ea"
+  end
+
+  resource "SQLite.swift" do
+    url "https://github.com/stephencelis/SQLite.swift/archive/refs/tags/0.16.0.tar.gz"
+    sha256 "b5a495909a7d4e31d85edf12bfede358222d3fe837f181a0faa79e3563060844"
+  end
+
+  def install
+    resources.each { |r| r.stage(buildpath/"vendor"/r.name) }
+    inreplace "Package.swift" do |s|
+      s.gsub! '.package(url: "https://github.com/steipete/Commander.git", from: "0.2.4")',
+              '.package(path: "vendor/Commander")'
+      s.gsub! '.package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.16.0")',
+              '.package(path: "vendor/SQLite.swift")'
+      s.gsub! '.package(url: "https://github.com/PhoneNumberKit/PhoneNumberKit.git", from: "5.0.5")',
+              '.package(path: "vendor/PhoneNumberKit")'
+    end
+
+    # Upstream patches its own SwiftPM checkouts before building; the resource
+    # bundle lookup fix in there is what lets imsg find its metadata at runtime.
+    inreplace "scripts/patch-deps.sh", ".build/checkouts", "vendor"
+    system "scripts/patch-deps.sh"
+
+    system "scripts/generate-version.sh"
+    system "swift", "build", "--disable-sandbox", "--configuration", "release", "--product", "imsg"
+
+    # Helper for the optional IMCore bridge, injected into Messages.app via
+    # DYLD_INSERT_LIBRARIES. Messages on Apple Silicon rejects arm64-only.
+    helper = "imsg-bridge-helper.dylib"
+    arch_args = (Hardware::CPU.arm? ? %w[arm64e arm64] : %w[x86_64]).flat_map { |arch| ["-arch", arch] }
+    ENV.permit_arch_flags
+    system ENV.cc, "-dynamiclib", *arch_args, "-fobjc-arc",
+           "-Wno-arc-performSelector-leaks", "-install_name", "@rpath/#{helper}",
+           "-framework", "Foundation", "-framework", "AppKit",
+           "-framework", "ImageIO", "-framework", "LinkPresentation",
+           "-o", helper, "Sources/IMsgHelper/IMsgInjected.m"
+
+    # Match upstream's ad-hoc signing so Automation and Contacts grants land on
+    # the same bundle identifier a release build would use. The helper is left
+    # alone: Homebrew rewrites its install name and re-signs it either way.
+    system "/usr/bin/codesign", "--force", "--sign", "-",
+           "--entitlements", "Resources/imsg.entitlements",
+           "--identifier", "com.steipete.imsg", ".build/release/imsg"
+
+    # imsg resolves its resource bundles and the bridge helper relative to the
+    # real executable, so they all have to live in the same directory.
+    libexec.install ".build/release/imsg", helper
+    libexec.install Dir[".build/release/*.bundle"]
+    bin.write_exec_script libexec/"imsg"
+
+    # bin/imsg is not executable until the install finishes, so shell out to the
+    # real binary here instead.
+    generate_completions_from_executable(libexec/"imsg", "completions")
+  end
+
+  def caveats
+    <<~EOS
+      imsg needs Full Disk Access to read the Messages database:
+        System Settings > Privacy & Security > Full Disk Access
+
+      Sending also needs permission to control Messages.app:
+        System Settings > Privacy & Security > Automation
+
+      Advanced IMCore features (typing indicators, read receipts, edit/unsend,
+      group management) additionally require SIP to be disabled. Check what is
+      available with:
+        imsg status
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/imsg --version")
+    assert_path_exists libexec/"imsg-bridge-helper.dylib"
+
+    # Exercises the PhoneNumberKit metadata bundle without needing Messages
+    # access or Full Disk Access.
+    touch testpath/"chat.db"
+    output = shell_output("#{bin}/imsg whois --address +14155551212 --type phone --local " \
+                          "--db #{testpath}/chat.db --json")
+    assert_match '"service":"unknown"', output
+  end
+end

--- a/Formula/imsg.rb
+++ b/Formula/imsg.rb
@@ -5,6 +5,12 @@ class Imsg < Formula
   sha256 "5fa216f8664cbc8abf4b0fe396d24f6c96b7e962d8a7c924d965d3d9e5068a8e"
   license "MIT"
 
+  bottle do
+    root_url "https://ghcr.io/v2/bevanjkay/formulae"
+    sha256 arm64_tahoe:   "691971fa78e7b27028ffdd9bf3491e4dcf087eecd9386cec6a3b24f1899df5df"
+    sha256 arm64_sequoia: "7c03184d260e58cff8c31d678c49e6cd9b1a3beba082c0ac9704f10e72a649b7"
+  end
+
   # A version-specified macOS requirement is satisfied on Linux, so the bare one
   # is what actually keeps this off a platform it cannot support.
   depends_on :macos


### PR DESCRIPTION
Adds `imsg` 0.13.4, built from source from `openclaw/imsg`.

## Build notes

- **Vendored SwiftPM dependencies.** Homebrew denies network access during
  builds, so `swift package resolve` cannot run. The three pinned dependencies
  from upstream's `Package.resolved` (Commander 0.2.4, PhoneNumberKit 5.0.5,
  SQLite.swift 0.16.0) ship as resources, and `Package.swift` is rewritten to
  point at the staged copies. The `inreplace` calls match the exact
  `.package(url:, from:)` strings, so a dependency bump upstream fails the
  build loudly instead of silently building against stale versions.
- **`depends_on macos: :sequoia`.** SQLite.swift 0.16.0 declares
  `swift-tools-version: 6.1`, which first ships in the Xcode 16.3 toolchain
  (macOS 15.3+). Sonoma tops out at Xcode 16.2 / Swift 6.0, so it cannot build
  this. Upstream's own prebuilt formula supports Sonoma; a source build cannot.
- **Layout follows upstream.** The binary, the SwiftPM resource bundles, and
  the bridge helper all go in `libexec` with a `bin` exec script, because imsg
  resolves both its PhoneNumberKit metadata bundle and the bridge helper
  relative to the real executable.
- **Bridge helper.** Built with the same `clang` invocation as upstream's
  `make build-dylib`, including the `arm64e` slice Messages.app requires on
  Apple Silicon. Homebrew rewrites its install name and re-signs it, so the
  formula does not bother signing it itself.
- **Ad-hoc signing.** The main binary is signed with upstream's entitlements
  and `com.steipete.imsg` identifier; verified to survive the install intact
  (`codesign --verify --strict` passes, entitlements present).

## Verification

- `brew style` and `brew audit --new --strict --online` clean
- `brew install --build-from-source` succeeds (53s), `brew test` passes,
  `brew linkage --test` clean
- Offline build confirmed against a `deny_all_network` sandbox before writing
  the formula
- `test do` exercises the PhoneNumberKit metadata bundle via
  `imsg whois --local`, which is the packaging failure mode most likely to
  regress, and needs neither Full Disk Access nor Messages.app

Bottles will need to be built for macOS 15 and 26; macOS 14 cannot compile this.
