### PR TITLE
wacli 0.15.0 (new formula)

### DIFF
--- a/Formula/wacli.rb
+++ b/Formula/wacli.rb
@@ -1,0 +1,34 @@
+class Wacli < Formula
+  desc "WhatsApp CLI built on whatsmeow"
+  homepage "https://github.com/openclaw/wacli"
+  url "https://github.com/openclaw/wacli/archive/refs/tags/v0.15.0.tar.gz"
+  sha256 "4e7aab088c8b46d1b4d498ec795b59067a7e6198faff86f89c4d4ad078d61ab9"
+  license "MIT"
+  head "https://github.com/openclaw/wacli.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    # go-sqlite3 needs cgo, and GCC 15+ with glibc 2.42+ treats missing-braces
+    # in Go's runtime/cgo as an error.
+    ENV["CGO_ENABLED"] = "1"
+    ENV.append "CGO_CFLAGS", "-Wno-error=missing-braces"
+
+    # Setting main.version alone is the source-build path upstream supports;
+    # main.releaseLinkerSetting is only for official release artifacts and makes
+    # the binary report "invalid-release-linker-version" if it disagrees.
+    system "go", "build",
+           *std_go_args(ldflags: "-X main.version=#{version}", tags: "sqlite_fts5"),
+           "./cmd/wacli"
+
+    generate_completions_from_executable(bin/"wacli", shell_parameter_format: :cobra)
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/wacli --version")
+
+    # Confirms the sqlite_fts5 build tag took effect; without it search silently
+    # degrades to LIKE.
+    assert_match(/FTS5\s+true/, shell_output("#{bin}/wacli doctor"))
+  end
+end

--- a/Formula/wacli.rb
+++ b/Formula/wacli.rb
@@ -6,6 +6,15 @@ class Wacli < Formula
   license "MIT"
   head "https://github.com/openclaw/wacli.git", branch: "main"
 
+  bottle do
+    root_url "https://ghcr.io/v2/bevanjkay/formulae"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6b39b6caccecaf1b57ca66fc87c999d50ca6dc9187cb9db23b3062473895e19b"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "da73a410009a87088b1c5f147a1e8718b881e179ab1173062f6f97ee74ee46ec"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "63c4df69fe309d7c7e98f13b2b90fe3e964243c99700f33c7ec7d280b8383c7d"
+    sha256 cellar: :any,                 arm64_linux:   "e308e2deb45953e9a8c4d564edc66f211da868a4fb2c3d4d69f2fe365f8b9399"
+    sha256 cellar: :any,                 x86_64_linux:  "1f6d66b567fdbb303c405216cf8cf557b611db8fc809958e271ff23acc78a98c"
+  end
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
Adds `wacli` 0.15.0, built from source from `openclaw/wacli`.

Plain Go build, so it follows the same shape as `protodump`. Three details are
upstream-specific:

- **cgo is required.** `go-sqlite3` needs it, so `CGO_ENABLED=1` plus the
  `-Wno-error=missing-braces` workaround upstream carries for GCC 15+ with
  glibc 2.42+ (matters for the Linux bottles, not macOS).
- **`sqlite_fts5` build tag.** Without it, message search silently falls back to
  `LIKE` instead of FTS5. The test asserts `FTS5 true` in `wacli doctor` rather
  than just matching the label, so a dropped tag fails the build instead of
  quietly shipping the slow path.
- **Only `main.version` is set via ldflags.** `effectiveVersion()` in
  `cmd/wacli/root.go` returns `"invalid-release-linker-version"` if
  `main.releaseLinkerSetting` is set but disagrees with `main.version`; that
  marker is for official release artifacts only. Setting `main.version` alone is
  the source-build path upstream supports.

## Verification

- `brew style` and `brew audit --new --strict --online` clean
- `brew install --build-from-source` succeeds, `brew test` passes
- `wacli --version` reports 0.15.0; `wacli doctor` reports `FTS5 true`
- Completions generated for bash, zsh, fish and pwsh (cobra)

No platform restriction: upstream supports macOS and Linux, so bottles for both.
